### PR TITLE
feat: 添加发送消息 topic 是否存在对应 consumer 配置校验，防止对应 topic 添加消息后，没有消费

### DIFF
--- a/delay-queue-redis-core/src/main/java/o2o/platform/commons/delay/queue/redis/core/service/DelayMessageProducer.java
+++ b/delay-queue-redis-core/src/main/java/o2o/platform/commons/delay/queue/redis/core/service/DelayMessageProducer.java
@@ -84,9 +84,11 @@ public class DelayMessageProducer {
 
     private void checkDelayMessage(DelayMessage delayMessage) {
         checkArgument(delayMessage != null, "延迟消息对象为空");
-        checkArgument(!isNullOrEmpty(delayMessage.getTopic()), "延迟消息Topic为空");
+        String topic = delayMessage.getTopic();
+        checkArgument(!isNullOrEmpty(topic), "延迟消息 Topic 为空");
+        checkArgument(delayQueueProperties.getTopics().containsKey(topic), "延迟消息 Topic 没有配置对应 Consumer 配置");
         checkArgument(delayMessage.getDelay() > 0 && delayMessage.getDelay() < MAX_DELAY_MILLS,
-                "延迟消息delay必须 >0 && < " + ofMillis(MAX_DELAY_MILLS).toDays() + "days");
+                "延迟消息 Delay 必须 > 0 && < " + ofMillis(MAX_DELAY_MILLS).toDays() + " days");
         checkArgument(delayMessage.getPayload() != null, "延迟消息内容不能为空");
     }
 


### PR DESCRIPTION
如果请求添加延时消息 topic 没有在 application 文件里面 delay.queue.topics 定义会造成无消费者消息堆积，添加发送消息校验后可屏蔽这部分消息